### PR TITLE
feature: use version 0.2.2 for elcli

### DIFF
--- a/elcli/action.yml
+++ b/elcli/action.yml
@@ -43,7 +43,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/unbrikd/elcli:0.2.1@sha256:d6701d6a777bc047f4a2b86f471e9c27ace96dc2d18c0de9303b76c4239139ac"
+  image: "docker://ghcr.io/unbrikd/elcli:0.2.2@sha256:732a567fb40e0cc318cb6aca7822285ba2841b9e6357aca0382fce0435f26305"
   args:
     - ${{ inputs.action }}
     - --token=${{ inputs.token }}


### PR DESCRIPTION
This PR bumps the elcli docker image from 0.2.1 to 0.2.2.